### PR TITLE
Add OKX support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Binance API keys (required for data access)
 BINANCE_API_KEY=your-binance-api-key
 BINANCE_API_SECRET=your-binance-api-secret
+OKX_API_KEY=your-okx-api-key
+OKX_API_SECRET=your-okx-api-secret
 # For running LLMs hosted by openai (gpt-4o, gpt-4o-mini, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
 OPENAI_API_KEY=your-open-ai-key

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This architecture provides several advantages:
 
 ### Prerequisites
 - Python 3.9 or higher (Python 3.12 recommended — used during development)
-- Binance account (required for accessing market data)
+ - Binance or OKX account (required for accessing market data)
 
 ⚠️ While Python 3.9+ should work, we recommend using Python 3.12 for full compatibility with the development environment.
 
@@ -183,9 +183,11 @@ cp .env.example .env
 
 5. Add your API keys to the `.env` file:
 ```
-# Binance API keys (required for data access)
+# Binance or OKX API keys (depending on the exchange you use)
 BINANCE_API_KEY=your-binance-api-key
 BINANCE_API_SECRET=your-binance-api-secret
+OKX_API_KEY=your-okx-api-key
+OKX_API_SECRET=your-okx-api-secret
 # For running LLMs hosted by openai (gpt-4o, gpt-4o-mini, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
 OPENAI_API_KEY=your-open-ai-key

--- a/README_CN.md
+++ b/README_CN.md
@@ -129,7 +129,7 @@ signals:
 
 ### 前提条件
 - Python 3.9或更高版本（推荐Python 3.12 — 开发时使用）
-- 币安账户（获取市场数据必需）
+ - 币安或OKX账户（获取市场数据必需）
 
 ⚠️ 虽然Python 3.9+应该可以工作，但我们建议使用Python 3.12以获得与开发环境的完全兼容性。
 
@@ -175,9 +175,11 @@ cp .env.example .env
 
 5. 在`.env`文件中添加API密钥：
 ```
-# 币安API密钥（获取数据必需）
+# 币安或OKX API密钥（根据选择的交易所）
 BINANCE_API_KEY=your-binance-api-key
 BINANCE_API_SECRET=your-binance-api-secret
+OKX_API_KEY=your-okx-api-key
+OKX_API_SECRET=your-okx-api-secret
 
 # LLM API密钥（如果使用AI助手）
 OPENAI_API_KEY=your-openai-api-key

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,5 @@
 mode: backtest
+exchange: binance
 start_date: 2025-04-01
 end_date: 2025-05-01
 primary_interval: 1h

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 mode: backtest # backtest, live
+exchange: binance
 start_date: 2025-04-20
 end_date: 2025-05-01
 primary_interval: 1h

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 mode: backtest # backtest, live
-exchange: binance
+exchange: okx
 start_date: 2025-04-20
 end_date: 2025-05-01
 primary_interval: 1h
@@ -9,10 +9,10 @@ show_reasoning: false
 show_agent_graph: true
 signals:
   intervals: ["30m", "1h", "4h"]
-  tickers: ["BTCUSDT", "ETHUSDT"]
+  tickers: ["BTC/USDT", "ETH/USDT"]
   strategies: ['MacdStrategy']
 # , "RSIStrategy"]
 model:
-  name: "gpt-4o-mini"
+  name: "gpt-4o"
   provider: "openai"
 #  base_url: "https://api.openai.com/v1"  #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "langchain-google-genai>=2.1.5",
     "langchain-anthropic>=0.3.15",
     "langchain-ollama>=0.3.3",
+    "okx>=2.1.2",
 ]
 
 #[tool.setuptools]

--- a/src/backtest/backtester.py
+++ b/src/backtest/backtester.py
@@ -7,6 +7,8 @@ from colorama import Fore, Style
 from utils import Interval, QUANTITY_DECIMALS, format_backtest_row, print_backtest_results
 from agent import Agent
 from utils.binance_data_provider import BinanceDataProvider
+from utils.okx_data_provider import OkxDataProvider
+from utils import settings
 import matplotlib.pyplot as plt
 
 
@@ -55,7 +57,10 @@ class Backtester:
         self.model_base_url = model_base_url
         self.show_agent_graph = show_agent_graph
         self.show_reasoning = show_reasoning
-        self.binance_data_provider = BinanceDataProvider()
+        if settings.exchange.lower() == "okx":
+            self.data_provider = OkxDataProvider()
+        else:
+            self.data_provider = BinanceDataProvider()
         self.klines: Dict[str, pd.DataFrame]() = {}
 
         # Initialize portfolio with support for long/short positions
@@ -275,10 +280,12 @@ class Backtester:
         print("\nPre-fetching data for the entire backtest period...")
         for ticker in self.tickers:
             # Fetch price data for the entire period
-            data = self.binance_data_provider.get_historical_klines(symbol=ticker,
-                                                                    timeframe=self.primary_interval.value,
-                                                                    start_date=self.start_date,
-                                                                    end_date=self.end_date)
+            data = self.data_provider.get_historical_klines(
+                symbol=ticker,
+                timeframe=self.primary_interval.value,
+                start_date=self.start_date,
+                end_date=self.end_date,
+            )
             self.klines[ticker] = data
 
         print("Data pre-fetch complete.")

--- a/src/graph/data_node.py
+++ b/src/graph/data_node.py
@@ -7,11 +7,14 @@ This module handles the first step in the workflow: fetching data from the data 
 from datetime import datetime, timedelta
 from typing import Dict, Any
 
-from src.utils import BinanceDataProvider, Interval
+from src.utils import BinanceDataProvider, OkxDataProvider, Interval, settings
 from .base_node import BaseNode, AgentState
 
 # Initialize data provider
-data_provider = BinanceDataProvider()
+if settings.exchange.lower() == "okx":
+    data_provider = OkxDataProvider()
+else:
+    data_provider = BinanceDataProvider()
 
 
 class DataNode(BaseNode):
@@ -20,7 +23,7 @@ class DataNode(BaseNode):
 
     def __call__(self, state: AgentState) -> Dict[str, Any]:
         """
-        Fetch data for all required timeframes using the BinanceDataProvider.
+        Fetch data for all required timeframes using the configured data provider.
 
         Args:
             state: The current state with symbol information

--- a/src/graph/start_node.py
+++ b/src/graph/start_node.py
@@ -5,10 +5,13 @@ start node
 from typing import Dict, Any
 
 from .base_node import BaseNode, AgentState
-from src.utils import BinanceDataProvider
+from src.utils import BinanceDataProvider, OkxDataProvider, settings
 
 # Initialize data provider
-data_provider = BinanceDataProvider()
+if settings.exchange.lower() == "okx":
+    data_provider = OkxDataProvider()
+else:
+    data_provider = BinanceDataProvider()
 
 
 class StartNode(BaseNode):

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,7 @@
 from .settings import settings
 from .constants import Interval, COLUMNS, NUMERIC_COLUMNS, QUANTITY_DECIMALS
 from .binance_data_provider import BinanceDataProvider
+from .okx_data_provider import OkxDataProvider
 from .util_func import (import_strategy_class,
                         save_graph_as_png,
                         deep_merge_dicts,
@@ -15,6 +16,7 @@ __all__ = ['settings',
            'NUMERIC_COLUMNS',
            'QUANTITY_DECIMALS',
            'BinanceDataProvider',
+           'OkxDataProvider',
            'import_strategy_class',
            'save_graph_as_png',
            'deep_merge_dicts',

--- a/src/utils/okx_data_provider.py
+++ b/src/utils/okx_data_provider.py
@@ -71,7 +71,7 @@ class OkxDataProvider:
                 "confirm",
             ],
         )
-        df["open_time"] = pd.to_datetime(df["open_time"], unit="ms")
+        df["open_time"] = pd.to_datetime(pd.to_numeric(df["open_time"]), unit="ms")
         df["close_time"] = df["open_time"] + pd.to_timedelta(self._timeframe_ms(timeframe), unit="ms")
         df["count"] = 0
         df["taker_buy_volume"] = 0
@@ -118,6 +118,7 @@ class OkxDataProvider:
         use_cache: bool = True,
     ) -> pd.DataFrame:
         formatted_symbol = symbol.replace("/", "-")
+        print(f"formatted_symbol: {formatted_symbol}")
         if start_date is None:
             start_date = datetime.now() - timedelta(days=30)
         if end_date is None:
@@ -130,13 +131,17 @@ class OkxDataProvider:
         before = int(end_date.timestamp() * 1000)
         all_rows = []
         while True:
+            print(f"get_history_candles instId: {formatted_symbol}, bar: {bar}, after: {start_ms}, before: {before}, limit: 100")
             res = self.client.get_history_candles(
                 instId=formatted_symbol,
                 bar=bar,
-                after=str(start_ms),
+                # after=str(start_ms),
                 before=str(before),
                 limit="100",
             )
+
+            print(f"res: {res}")
+
             if res.get("code") != "0":
                 break
             data = res.get("data", [])

--- a/src/utils/okx_data_provider.py
+++ b/src/utils/okx_data_provider.py
@@ -1,0 +1,154 @@
+from typing import Optional
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+from okx.api import Market
+
+from .constants import COLUMNS, NUMERIC_COLUMNS
+
+
+class OkxDataProvider:
+    """Data provider for fetching OHLCV data from OKX."""
+
+    def __init__(self, api_key: Optional[str] = None, api_secret: Optional[str] = None, passphrase: Optional[str] = None):
+        self.client = Market()
+        self.cache_dir = Path("./cache")
+        self.cache_dir.mkdir(exist_ok=True)
+
+    @staticmethod
+    def _format_timeframe(timeframe: str) -> str:
+        mapping = {
+            "1m": "1m",
+            "3m": "3m",
+            "5m": "5m",
+            "15m": "15m",
+            "30m": "30m",
+            "1h": "1H",
+            "2h": "2H",
+            "4h": "4H",
+            "6h": "6H",
+            "12h": "12H",
+            "1d": "1D",
+            "1w": "1W",
+            "1M": "1M",
+        }
+        return mapping.get(timeframe, timeframe)
+
+    @staticmethod
+    def _timeframe_ms(timeframe: str) -> int:
+        mapping = {
+            "1m": 60_000,
+            "3m": 3 * 60_000,
+            "5m": 5 * 60_000,
+            "15m": 15 * 60_000,
+            "30m": 30 * 60_000,
+            "1h": 60 * 60_000,
+            "2h": 2 * 60 * 60_000,
+            "4h": 4 * 60 * 60_000,
+            "6h": 6 * 60 * 60_000,
+            "12h": 12 * 60 * 60_000,
+            "1d": 24 * 60 * 60_000,
+            "1w": 7 * 24 * 60 * 60_000,
+            "1M": 30 * 24 * 60 * 60_000,
+        }
+        return mapping.get(timeframe, 60_000)
+
+    def _to_df(self, data: list, timeframe: str) -> pd.DataFrame:
+        if not data:
+            return pd.DataFrame()
+        df = pd.DataFrame(
+            data,
+            columns=[
+                "open_time",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "quote_volume",
+                "_vol_quote",
+                "confirm",
+            ],
+        )
+        df["open_time"] = pd.to_datetime(df["open_time"], unit="ms")
+        df["close_time"] = df["open_time"] + pd.to_timedelta(self._timeframe_ms(timeframe), unit="ms")
+        df["count"] = 0
+        df["taker_buy_volume"] = 0
+        df["taker_buy_quote_volume"] = 0
+        df["ignore"] = 0
+        df = df[COLUMNS]
+        for col in NUMERIC_COLUMNS:
+            df[col] = pd.to_numeric(df[col])
+        return df
+
+    def get_history_klines_with_end_time(
+        self,
+        symbol: str,
+        timeframe: str,
+        end_time: datetime,
+        limit: int = 500,
+    ) -> pd.DataFrame:
+        bar = self._format_timeframe(timeframe)
+        formatted_symbol = symbol.replace("/", "-")
+        res = self.client.get_history_candles(
+            instId=formatted_symbol,
+            bar=bar,
+            before=str(int(end_time.timestamp() * 1000)),
+            limit=str(limit),
+        )
+        if res.get("code") != "0":
+            return pd.DataFrame()
+        return self._to_df(res.get("data", []), timeframe)
+
+    def get_latest_data(self, symbol: str, timeframe: str, limit: int = 100) -> pd.DataFrame:
+        bar = self._format_timeframe(timeframe)
+        formatted_symbol = symbol.replace("/", "-")
+        res = self.client.get_candles(instId=formatted_symbol, bar=bar, limit=str(limit))
+        if res.get("code") != "0":
+            return pd.DataFrame()
+        return self._to_df(res.get("data", []), timeframe)
+
+    def get_historical_klines(
+        self,
+        symbol: str,
+        timeframe: str,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+        use_cache: bool = True,
+    ) -> pd.DataFrame:
+        formatted_symbol = symbol.replace("/", "-")
+        if start_date is None:
+            start_date = datetime.now() - timedelta(days=30)
+        if end_date is None:
+            end_date = datetime.now()
+        cache_file = self.cache_dir / f"{formatted_symbol}_{timeframe}_{start_date.strftime('%Y%m%d')}_{end_date.strftime('%Y%m%d')}.csv"
+        if use_cache and cache_file.exists():
+            return pd.read_csv(cache_file, parse_dates=["open_time", "close_time"])
+        bar = self._format_timeframe(timeframe)
+        start_ms = int(start_date.timestamp() * 1000)
+        before = int(end_date.timestamp() * 1000)
+        all_rows = []
+        while True:
+            res = self.client.get_history_candles(
+                instId=formatted_symbol,
+                bar=bar,
+                after=str(start_ms),
+                before=str(before),
+                limit="100",
+            )
+            if res.get("code") != "0":
+                break
+            data = res.get("data", [])
+            if not data:
+                break
+            all_rows.extend(data)
+            last_ts = int(data[-1][0])
+            if last_ts <= start_ms or len(data) < 100:
+                break
+            before = last_ts
+        df = self._to_df(all_rows, timeframe)
+        df = df.sort_values("open_time")
+        if use_cache and not df.empty:
+            df.to_csv(cache_file, index=False)
+        return df

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -22,6 +22,7 @@ class ModelSettings(BaseModel):
 
 
 class Settings(BaseSettings):
+    exchange: str = "binance"
     mode: str
     start_date: datetime
     end_date: datetime


### PR DESCRIPTION
## Summary
- add `okx` library to dependencies
- implement `OkxDataProvider` for retrieving OHLCV data
- allow selecting exchange via `exchange` field in settings
- update data nodes and backtester to use OKX when selected
- document OKX usage in README files and config examples
- add OKX API keys to `.env.example`

## Testing
- `python -m py_compile src/graph/data_node.py src/graph/start_node.py src/backtest/backtester.py src/utils/okx_data_provider.py src/utils/__init__.py src/utils/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_685a40fe65a8832babcbd69fb71c15d4